### PR TITLE
quick fix remove event listeners in wait command

### DIFF
--- a/packages/entourage-cli/src/command.js
+++ b/packages/entourage-cli/src/command.js
@@ -150,14 +150,10 @@ export const wait = async argv => {
   eventBus.addListener(eventName, data => {
     // console.log('message received :', args);
     ready = data.ready;
-    client.end(true);
   });
 
   const timeoutFn = setTimeout(() => {
-    eventBus.removeListener(eventName, () => {
-      client.end(true);
-      timedout = true;
-    });
+    timedout = true;
   }, config.timeout);
 
   while (!ready && !timedout) {
@@ -167,6 +163,8 @@ export const wait = async argv => {
 
   stopProgressDots();
   clearTimeout(timeoutFn);
+  eventBus.removeAllListeners(eventName);
+  client.end(true);
 
   if (!ready) {
     if (timedout) {


### PR DESCRIPTION
While working with event listeners yesterday it made me think of bringing this quick fix in entourage-cli.
I forgot there might be an issue in the previous approach, as the callback for `removeListener` should be the same than `addListener`.